### PR TITLE
Support ElasticSearch 5.X

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,7 @@ The configuration options are as follows:
     "address": <address>,
     "transportAddresses": [ { "hostname": <hostname>, "port": <port> } ],
     "cluster_name": <cluster_name>,
-    "client_transport_sniff": <client_transport_sniff>,
-    "requireUnits": false
+    "client_transport_sniff": <client_transport_sniff>
 }
 ```
 
@@ -49,7 +48,6 @@ The configuration options are as follows:
     * `port` - the port of the node to connect to.  The default is `9300`.
 * `cluster_name` - the elastic search cluster name.  The default is `"elasticsearch"`.
 * `client_transport_sniff` - the client will sniff the rest of the cluster and add those into its list of machines to use.  The default is `true`.
-* `requireUnits` - boolean flag whether units are required.  The default is `false`.
 
 An example configuration would be:
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The difference to [ef-labs/vertx-elasticsearch-service](https://github.com/ef-la
 | --------- | -------------- | ---------------------------     |
 | 3.3.3     | 2.2.2          | 1.0.0                           |
 | 3.3.3     | 2.2.2          | 1.1.0                           |
-
+| 3.5.0     | 5.6.1          | 1.3.0                           |
 
 ## Compatibility
 - Java 8+

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     </parent>
     <groupId>com.hubrick.vertx</groupId>
     <artifactId>vertx-elasticsearch-service</artifactId>
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
     <inceptionYear>2016</inceptionYear>
     <licenses>
         <license>
@@ -36,11 +36,11 @@
         <java.version>1.8</java.version>
         <arguments />
 
-        <vertx.version>3.3.3</vertx.version>
-        <es.version>2.4.4</es.version>
-        <lucene.version>5.4.1</lucene.version>
+        <vertx.version>3.5.0</vertx.version>
+        <es.version>5.6.2</es.version>
+        <lucene.version>6.6.1</lucene.version>
         <vertx.hk2.version>2.4.0</vertx.hk2.version>
-        <vertx.guice.version>2.3.0</vertx.guice.version>
+        <vertx.guice.version>2.3.1</vertx.guice.version>
         <when.version>4.1.1</when.version>
         <hamcrest.version>1.3</hamcrest.version>
         <junit.version>4.12</junit.version>
@@ -78,8 +78,8 @@
             <version>${es.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.elasticsearch.plugin</groupId>
-            <artifactId>delete-by-query</artifactId>
+            <groupId>org.elasticsearch.client</groupId>
+            <artifactId>transport</artifactId>
             <version>${es.version}</version>
         </dependency>
         <dependency>
@@ -115,13 +115,6 @@
         </dependency>
 
         <!--Test dependencies-->
-        <dependency>
-            <groupId>org.elasticsearch</groupId>
-            <artifactId>elasticsearch</artifactId>
-            <version>${es.version}</version>
-            <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-test-framework</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -203,6 +203,7 @@
                     </compilerArgs>
                 </configuration>
             </plugin>
+            <!--
             <plugin>
                 <groupId>com.alexecollins.docker</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
@@ -238,6 +239,7 @@
                     </dependency>
                 </dependencies>
             </plugin>
+            -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>

--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -33,6 +33,7 @@
 ^|Name | Type ^| Description
 |[[definition]]`definition`|`Json object`|-
 |[[name]]`name`|`String`|-
+|[[subAggregations]]`subAggregations`|`Array of link:dataobjects.html#AggregationOption[AggregationOption]`|-
 |[[type]]`type`|`link:enums.html#AggregationType[AggregationType]`|-
 |===
 

--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -386,7 +386,6 @@
 |[[aggregations]]`aggregations`|`Array of link:dataobjects.html#AggregationOption[AggregationOption]`|-
 |[[explain]]`explain`|`Boolean`|-
 |[[fetchSource]]`fetchSource`|`Boolean`|-
-|[[fields]]`fields`|`Array of String`|-
 |[[from]]`from`|`Number (Integer)`|-
 |[[minScore]]`minScore`|`Number (Float)`|-
 |[[postFilter]]`postFilter`|`Json object`|-
@@ -398,6 +397,8 @@
 |[[searchType]]`searchType`|`link:enums.html#SearchType[SearchType]`|-
 |[[size]]`size`|`Number (Integer)`|-
 |[[sorts]]`sorts`|`Array of link:dataobjects.html#BaseSortOption[BaseSortOption]`|-
+|[[sourceExcludes]]`sourceExcludes`|`Array of String`|-
+|[[sourceIncludes]]`sourceIncludes`|`Array of String`|-
 |[[terminateAfter]]`terminateAfter`|`Number (Integer)`|-
 |[[timeout]]`timeout`|`String`|-
 |[[trackScores]]`trackScores`|`Boolean`|-

--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -19,6 +19,23 @@
 |[[version]]`version`|`Number (Long)`|-
 |===
 
+[[AggregationOption]]
+== AggregationOption
+
+++++
+ Aggregation option
+++++
+'''
+
+[cols=">25%,^25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
+|[[definition]]`definition`|`Json object`|-
+|[[name]]`name`|`String`|-
+|[[type]]`type`|`link:enums.html#AggregationType[AggregationType]`|-
+|===
+
 [[BaseSortOption]]
 == BaseSortOption
 
@@ -91,13 +108,15 @@
 [frame="topbot"]
 |===
 ^|Name | Type ^| Description
+|[[batches]]`batches`|`Number (Integer)`|-
+|[[deleted]]`deleted`|`Number (Long)`|-
+|[[failures]]`failures`|`Json array`|-
 |[[rawResponse]]`rawResponse`|`Json object`|-
+|[[retries]]`retries`|`Number (Long)`|-
+|[[throttled]]`throttled`|`Number (Long)`|-
 |[[timedOut]]`timedOut`|`Boolean`|-
 |[[took]]`took`|`Number (Long)`|-
-|[[totalDeleted]]`totalDeleted`|`Number (Long)`|-
-|[[totalFailed]]`totalFailed`|`Number (Long)`|-
-|[[totalFound]]`totalFound`|`Number (Long)`|-
-|[[totalMissing]]`totalMissing`|`Number (Long)`|-
+|[[versionConflicts]]`versionConflicts`|`Number (Long)`|-
 |===
 
 [[DeleteOptions]]
@@ -112,13 +131,13 @@
 [frame="topbot"]
 |===
 ^|Name | Type ^| Description
-|[[consistencyLevel]]`consistencyLevel`|`link:enums.html#WriteConsistencyLevel[WriteConsistencyLevel]`|-
 |[[parent]]`parent`|`String`|-
 |[[refresh]]`refresh`|`Boolean`|-
 |[[routing]]`routing`|`String`|-
 |[[timeout]]`timeout`|`String`|-
 |[[version]]`version`|`Number (Long)`|-
 |[[versionType]]`versionType`|`link:enums.html#VersionType[VersionType]`|-
+|[[waitForActiveShard]]`waitForActiveShard`|`Number (Integer)`|-
 |===
 
 [[DeleteResponse]]
@@ -184,13 +203,11 @@
 |[[fetchSourceExcludes]]`fetchSourceExcludes`|`Array of String`|-
 |[[fetchSourceIncludes]]`fetchSourceIncludes`|`Array of String`|-
 |[[fields]]`fields`|`Array of String`|-
-|[[ignoreErrorsOnGeneratedFields]]`ignoreErrorsOnGeneratedFields`|`Boolean`|-
 |[[parent]]`parent`|`String`|-
 |[[preference]]`preference`|`String`|-
 |[[realtime]]`realtime`|`Boolean`|-
 |[[refresh]]`refresh`|`Boolean`|-
 |[[routing]]`routing`|`String`|-
-|[[transformSource]]`transformSource`|`Boolean`|-
 |[[version]]`version`|`Number (Long)`|-
 |[[versionType]]`versionType`|`link:enums.html#VersionType[VersionType]`|-
 |===
@@ -273,7 +290,6 @@
 [frame="topbot"]
 |===
 ^|Name | Type ^| Description
-|[[consistencyLevel]]`consistencyLevel`|`link:enums.html#WriteConsistencyLevel[WriteConsistencyLevel]`|-
 |[[id]]`id`|`String`|-
 |[[opType]]`opType`|`link:enums.html#OpType[OpType]`|-
 |[[parent]]`parent`|`String`|-
@@ -284,6 +300,7 @@
 |[[ttl]]`ttl`|`Number (Long)`|-
 |[[version]]`version`|`Number (Long)`|-
 |[[versionType]]`versionType`|`link:enums.html#VersionType[VersionType]`|-
+|[[waitForActiveShard]]`waitForActiveShard`|`Number (Integer)`|-
 |===
 
 [[IndexResponse]]
@@ -366,9 +383,8 @@
 [frame="topbot"]
 |===
 ^|Name | Type ^| Description
-|[[aggregations]]`aggregations`|`Json object`|-
+|[[aggregations]]`aggregations`|`Array of link:dataobjects.html#AggregationOption[AggregationOption]`|-
 |[[explain]]`explain`|`Boolean`|-
-|[[extraSource]]`extraSource`|`Json object`|-
 |[[fetchSource]]`fetchSource`|`Boolean`|-
 |[[fields]]`fields`|`Array of String`|-
 |[[from]]`from`|`Number (Integer)`|-
@@ -382,9 +398,6 @@
 |[[searchType]]`searchType`|`link:enums.html#SearchType[SearchType]`|-
 |[[size]]`size`|`Number (Integer)`|-
 |[[sorts]]`sorts`|`Array of link:dataobjects.html#BaseSortOption[BaseSortOption]`|-
-|[[templateName]]`templateName`|`String`|-
-|[[templateParams]]`templateParams`|`Json object`|-
-|[[templateType]]`templateType`|`link:enums.html#ScriptType[ScriptType]`|-
 |[[terminateAfter]]`terminateAfter`|`Number (Integer)`|-
 |[[timeout]]`timeout`|`String`|-
 |[[trackScores]]`trackScores`|`Boolean`|-
@@ -539,7 +552,6 @@
 [frame="topbot"]
 |===
 ^|Name | Type ^| Description
-|[[consistencyLevel]]`consistencyLevel`|`link:enums.html#WriteConsistencyLevel[WriteConsistencyLevel]`|-
 |[[detectNoop]]`detectNoop`|`Boolean`|-
 |[[doc]]`doc`|`Json object`|-
 |[[docAsUpsert]]`docAsUpsert`|`Boolean`|-
@@ -557,6 +569,7 @@
 |[[upsert]]`upsert`|`Json object`|-
 |[[version]]`version`|`Number (Long)`|-
 |[[versionType]]`versionType`|`link:enums.html#VersionType[VersionType]`|-
+|[[waitForActiveShard]]`waitForActiveShard`|`Number (Integer)`|-
 |===
 
 [[UpdateResponse]]

--- a/src/main/java/com/hubrick/vertx/elasticsearch/ElasticSearchConfigurator.java
+++ b/src/main/java/com/hubrick/vertx/elasticsearch/ElasticSearchConfigurator.java
@@ -28,8 +28,6 @@ public interface ElasticSearchConfigurator {
 
     boolean getClientTransportSniff();
 
-    boolean getSettingsRequireUnits();
-
     List<TransportAddress> getTransportAddresses();
 
 }

--- a/src/main/java/com/hubrick/vertx/elasticsearch/impl/DefaultElasticSearchAdminService.java
+++ b/src/main/java/com/hubrick/vertx/elasticsearch/impl/DefaultElasticSearchAdminService.java
@@ -65,7 +65,7 @@ public class DefaultElasticSearchAdminService implements InternalElasticSearchAd
             }
 
             @Override
-            public void onFailure(Throwable e) {
+            public void onFailure(Exception e) {
                 resultHandler.handle(Future.failedFuture(e));
             }
         });

--- a/src/main/java/com/hubrick/vertx/elasticsearch/impl/DefaultElasticSearchService.java
+++ b/src/main/java/com/hubrick/vertx/elasticsearch/impl/DefaultElasticSearchService.java
@@ -19,19 +19,7 @@ import com.hubrick.vertx.elasticsearch.ElasticSearchConfigurator;
 import com.hubrick.vertx.elasticsearch.ElasticSearchService;
 import com.hubrick.vertx.elasticsearch.TransportClientFactory;
 import com.hubrick.vertx.elasticsearch.internal.InternalElasticSearchService;
-import com.hubrick.vertx.elasticsearch.model.BaseSortOption;
-import com.hubrick.vertx.elasticsearch.model.BaseSuggestOption;
-import com.hubrick.vertx.elasticsearch.model.CompletionSuggestOption;
-import com.hubrick.vertx.elasticsearch.model.DeleteByQueryOptions;
-import com.hubrick.vertx.elasticsearch.model.DeleteOptions;
-import com.hubrick.vertx.elasticsearch.model.FieldSortOption;
-import com.hubrick.vertx.elasticsearch.model.GetOptions;
-import com.hubrick.vertx.elasticsearch.model.IndexOptions;
-import com.hubrick.vertx.elasticsearch.model.ScriptSortOption;
-import com.hubrick.vertx.elasticsearch.model.SearchOptions;
-import com.hubrick.vertx.elasticsearch.model.SearchScrollOptions;
-import com.hubrick.vertx.elasticsearch.model.SuggestOptions;
-import com.hubrick.vertx.elasticsearch.model.UpdateOptions;
+import com.hubrick.vertx.elasticsearch.model.*;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -43,9 +31,6 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.delete.DeleteRequestBuilder;
 import org.elasticsearch.action.delete.DeleteResponse;
-import org.elasticsearch.action.deletebyquery.DeleteByQueryAction;
-import org.elasticsearch.action.deletebyquery.DeleteByQueryRequestBuilder;
-import org.elasticsearch.action.deletebyquery.DeleteByQueryResponse;
 import org.elasticsearch.action.get.GetRequestBuilder;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.index.IndexRequestBuilder;
@@ -53,31 +38,66 @@ import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchScrollRequestBuilder;
-import org.elasticsearch.action.suggest.SuggestRequestBuilder;
-import org.elasticsearch.action.suggest.SuggestResponse;
+import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.action.update.UpdateRequestBuilder;
 import org.elasticsearch.action.update.UpdateResponse;
 import org.elasticsearch.client.transport.TransportClient;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.query.QueryParseContext;
+import org.elasticsearch.index.reindex.BulkByScrollResponse;
+import org.elasticsearch.index.reindex.DeleteByQueryAction;
+import org.elasticsearch.index.reindex.DeleteByQueryRequestBuilder;
 import org.elasticsearch.script.Script;
-import org.elasticsearch.script.ScriptService;
-import org.elasticsearch.script.Template;
+import org.elasticsearch.script.ScriptType;
+import org.elasticsearch.search.aggregations.bucket.adjacency.AdjacencyMatrixAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.filter.FilterAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.filters.FiltersAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.geogrid.GeoGridAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.global.GlobalAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.histogram.HistogramAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.missing.MissingAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.nested.NestedAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.nested.ReverseNestedAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.range.RangeAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.range.date.DateRangeAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.range.geodistance.GeoDistanceAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.range.ip.IpRangeAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.sampler.DiversifiedAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.sampler.SamplerAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.avg.AvgAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.cardinality.CardinalityAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.geobounds.GeoBoundsAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.geocentroid.GeoCentroidAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.max.MaxAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.min.MinAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.percentiles.PercentileRanksAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.percentiles.PercentilesAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.scripted.ScriptedMetricAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.stats.StatsAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.stats.extended.ExtendedStatsAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.sum.SumAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.tophits.TopHitsAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.valuecount.ValueCountAggregationBuilder;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.sort.ScriptSortBuilder;
+import org.elasticsearch.search.suggest.SuggestBuilder;
 import org.elasticsearch.search.suggest.completion.CompletionSuggestionBuilder;
 
 import javax.inject.Inject;
+import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-import static com.hubrick.vertx.elasticsearch.impl.ElasticSearchServiceMapper.mapToDeleteByQueryResponse;
-import static com.hubrick.vertx.elasticsearch.impl.ElasticSearchServiceMapper.mapToDeleteResponse;
-import static com.hubrick.vertx.elasticsearch.impl.ElasticSearchServiceMapper.mapToIndexResponse;
-import static com.hubrick.vertx.elasticsearch.impl.ElasticSearchServiceMapper.mapToSearchResponse;
-import static com.hubrick.vertx.elasticsearch.impl.ElasticSearchServiceMapper.mapToSuggestResponse;
-import static com.hubrick.vertx.elasticsearch.impl.ElasticSearchServiceMapper.mapToUpdateResponse;
+import static com.hubrick.vertx.elasticsearch.impl.ElasticSearchServiceMapper.*;
 
 /**
  * Default implementation of {@link ElasticSearchService}
@@ -99,8 +119,6 @@ public class DefaultElasticSearchService implements InternalElasticSearchService
 
     @Override
     public void start() {
-
-        Settings.setSettingsRequireUnits(configurator.getSettingsRequireUnits());
 
         Settings settings = Settings.builder()
                 .put("cluster.name", configurator.getClusterName())
@@ -129,8 +147,8 @@ public class DefaultElasticSearchService implements InternalElasticSearchService
             if (options.getRouting() != null) builder.setRouting(options.getRouting());
             if (options.getParent() != null) builder.setParent(options.getParent());
             if (options.getOpType() != null) builder.setOpType(options.getOpType());
-            if (options.isRefresh() != null) builder.setRefresh(options.isRefresh());
-            if (options.getConsistencyLevel() != null) builder.setConsistencyLevel(options.getConsistencyLevel());
+            if (options.getWaitForActiveShard() != null) builder.setWaitForActiveShards(options.getWaitForActiveShard());
+            if (options.isRefresh() != null) builder.setRefreshPolicy(options.isRefresh() ? WriteRequest.RefreshPolicy.IMMEDIATE : WriteRequest.RefreshPolicy.NONE);
             if (options.getVersion() != null) builder.setVersion(options.getVersion());
             if (options.getVersionType() != null) builder.setVersionType(options.getVersionType());
             if (options.getTimestamp() != null) builder.setTimestamp(options.getTimestamp());
@@ -145,8 +163,8 @@ public class DefaultElasticSearchService implements InternalElasticSearchService
             }
 
             @Override
-            public void onFailure(Throwable t) {
-                handleFailure(resultHandler, t);
+            public void onFailure(Exception e) {
+                handleFailure(resultHandler, e);
             }
         });
 
@@ -160,8 +178,8 @@ public class DefaultElasticSearchService implements InternalElasticSearchService
         if (options != null) {
             if (options.getRouting() != null) builder.setRouting(options.getRouting());
             if (options.getParent() != null) builder.setParent(options.getParent());
-            if (options.isRefresh() != null) builder.setRefresh(options.isRefresh());
-            if (options.getConsistencyLevel() != null) builder.setConsistencyLevel(options.getConsistencyLevel());
+            if (options.isRefresh() != null) builder.setRefreshPolicy(options.isRefresh() ? WriteRequest.RefreshPolicy.IMMEDIATE : WriteRequest.RefreshPolicy.NONE);
+            if (options.getWaitForActiveShard() != null) builder.setWaitForActiveShards(options.getWaitForActiveShard());
             if (options.getVersion() != null) builder.setVersion(options.getVersion());
             if (options.getVersionType() != null) builder.setVersionType(options.getVersionType());
             if (options.getTimeout() != null) builder.setTimeout(options.getTimeout());
@@ -175,8 +193,8 @@ public class DefaultElasticSearchService implements InternalElasticSearchService
 
             if (options.getScript() != null) {
                 if (options.getScriptType() != null) {
-                    Map<String, ? extends Object> params = (options.getScriptParams() == null ? null : convertJsonObjectToMap(options.getScriptParams()));
-                    builder.setScript(new Script(options.getScript(), options.getScriptType(), options.getScriptLang(), params));
+                    Map<String, Object> params = (options.getScriptParams() == null ? null : convertJsonObjectToMap(options.getScriptParams()));
+                    builder.setScript(new Script(options.getScriptType(), options.getScriptLang(), options.getScript(), params));
                 } else {
                     builder.setScript(new Script(options.getScript()));
                 }
@@ -193,7 +211,7 @@ public class DefaultElasticSearchService implements InternalElasticSearchService
             }
 
             @Override
-            public void onFailure(Throwable e) {
+            public void onFailure(Exception e) {
                 handleFailure(resultHandler, e);
             }
         });
@@ -214,7 +232,7 @@ public class DefaultElasticSearchService implements InternalElasticSearchService
 
             if (options.getPreference() != null) builder.setPreference(options.getPreference());
             if (!options.getFields().isEmpty()) {
-                builder.setFields(options.getFields().toArray(new String[options.getFields().size()]));
+                builder.setStoredFields(options.getFields().toArray(new String[options.getFields().size()]));
             }
             if (options.isFetchSource() != null) builder.setFetchSource(options.isFetchSource());
             if (!options.getFetchSourceIncludes().isEmpty() || !options.getFetchSourceExcludes().isEmpty()) {
@@ -222,11 +240,7 @@ public class DefaultElasticSearchService implements InternalElasticSearchService
                 String[] excludes = options.getFetchSourceExcludes().toArray(new String[options.getFetchSourceExcludes().size()]);
                 builder.setFetchSource(includes, excludes);
             }
-            if (options.isTransformSource() != null) builder.setTransformSource(options.isTransformSource());
             if (options.isRealtime() != null) builder.setRealtime(options.isRealtime());
-            if (options.isIgnoreErrorsOnGeneratedFields() != null) {
-                builder.setIgnoreErrorsOnGeneratedFields(options.isIgnoreErrorsOnGeneratedFields());
-            }
         }
 
         builder.execute(new ActionListener<GetResponse>() {
@@ -236,7 +250,7 @@ public class DefaultElasticSearchService implements InternalElasticSearchService
             }
 
             @Override
-            public void onFailure(Throwable t) {
+            public void onFailure(Exception t) {
                 handleFailure(resultHandler, t);
             }
         });
@@ -254,22 +268,125 @@ public class DefaultElasticSearchService implements InternalElasticSearchService
             }
             if (options.getSearchType() != null) builder.setSearchType(options.getSearchType());
             if (options.getScroll() != null) builder.setScroll(options.getScroll());
-            if (options.getTimeout() != null) builder.setTimeout(options.getTimeout());
+            if (options.getTimeout() != null) builder.setTimeout(TimeValue.parseTimeValue(options.getTimeout(), ""));
             if (options.getTerminateAfter() != null) builder.setTerminateAfter(options.getTerminateAfter());
             if (options.getRouting() != null) builder.setRouting(options.getRouting());
             if (options.getPreference() != null) builder.setPreference(options.getPreference());
-            if (options.getQuery() != null) builder.setQuery(options.getQuery().encode());
-            if (options.getPostFilter() != null) builder.setPostFilter(options.getPostFilter().encode());
+            if (options.getQuery() != null) builder.setQuery(QueryBuilders.wrapperQuery(options.getQuery().encode()));
+            if (options.getPostFilter() != null) builder.setPostFilter(QueryBuilders.wrapperQuery(options.getPostFilter().encode()));
             if (options.getMinScore() != null) builder.setMinScore(options.getMinScore());
             if (options.getSize() != null) builder.setSize(options.getSize());
             if (options.getFrom() != null) builder.setFrom(options.getFrom());
             if (options.isExplain() != null) builder.setExplain(options.isExplain());
             if (options.isVersion() != null) builder.setVersion(options.isVersion());
             if (options.isFetchSource() != null) builder.setFetchSource(options.isFetchSource());
-            if (!options.getFields().isEmpty()) options.getFields().forEach(builder::addField);
+            if (!options.getFields().isEmpty()) options.getFields().forEach(builder::addStoredField);
             if (options.isTrackScores() != null) builder.setTrackScores(options.isTrackScores());
             if (options.getAggregations() != null) {
-                builder.setAggregations(options.getAggregations().encode().getBytes(CHARSET_UTF8));
+                options.getAggregations().forEach(aggregationOption -> {
+                    try {
+                        QueryParseContext context = new QueryParseContext(XContentType.JSON.xContent().createParser(NamedXContentRegistry.EMPTY, aggregationOption.getDefinition().encode()));
+                        switch (aggregationOption.getType()) {
+                            case TERMS:
+                                builder.addAggregation(TermsAggregationBuilder.parse(aggregationOption.getName(), context));
+                                break;
+                            case MAX:
+                                builder.addAggregation(MaxAggregationBuilder.parse(aggregationOption.getName(), context));
+                                break;
+                            case MIN:
+                                builder.addAggregation(MinAggregationBuilder.parse(aggregationOption.getName(), context));
+                                break;
+                            case ADJACENCY_MATRIX:
+                                builder.addAggregation(AdjacencyMatrixAggregationBuilder.getParser().parse(aggregationOption.getName(), context));
+                                break;
+                            case SUM:
+                                builder.addAggregation(SumAggregationBuilder.parse(aggregationOption.getName(), context));
+                                break;
+                            case RANGE:
+                                builder.addAggregation(RangeAggregationBuilder.parse(aggregationOption.getName(), context));
+                                break;
+                            case STATS:
+                                builder.addAggregation(StatsAggregationBuilder.parse(aggregationOption.getName(), context));
+                                break;
+                            case FILTER:
+                                builder.addAggregation(FilterAggregationBuilder.parse(aggregationOption.getName(), context));
+                                break;
+                            case GLOBAL:
+                                builder.addAggregation(GlobalAggregationBuilder.parse(aggregationOption.getName(), context));
+                                break;
+                            case NESTED:
+                                builder.addAggregation(NestedAggregationBuilder.parse(aggregationOption.getName(), context));
+                                break;
+                            case AVERAGE:
+                                builder.addAggregation(AvgAggregationBuilder.parse(aggregationOption.getName(), context));
+                                break;
+                            case FILTERS:
+                                builder.addAggregation(FiltersAggregationBuilder.parse(aggregationOption.getName(), context));
+                                break;
+                            case MISSING:
+                                builder.addAggregation(MissingAggregationBuilder.parse(aggregationOption.getName(), context));
+                                break;
+                            case SAMPLER:
+                                builder.addAggregation(SamplerAggregationBuilder.parse(aggregationOption.getName(), context));
+                                break;
+                            case GEO_GRID:
+                                builder.addAggregation(GeoGridAggregationBuilder.parse(aggregationOption.getName(), context));
+                                break;
+                            case IP_RANGE:
+                                builder.addAggregation(IpRangeAggregationBuilder.parse(aggregationOption.getName(), context));
+                                break;
+                            case TOP_HITS:
+                                builder.addAggregation(TopHitsAggregationBuilder.parse(aggregationOption.getName(), context));
+                                break;
+                            case HISTOGRAM:
+                                builder.addAggregation(HistogramAggregationBuilder.parse(aggregationOption.getName(), context));
+                                break;
+                            case DATE_RANGE:
+                                builder.addAggregation(DateRangeAggregationBuilder.parse(aggregationOption.getName(), context));
+                                break;
+                            case GEO_BOUNDS:
+                                builder.addAggregation(GeoBoundsAggregationBuilder.parse(aggregationOption.getName(), context));
+                                break;
+                            case CARDINALITY:
+                                builder.addAggregation(CardinalityAggregationBuilder.parse(aggregationOption.getName(), context));
+                                break;
+                            case PERCENTILES:
+                                builder.addAggregation(PercentilesAggregationBuilder.parse(aggregationOption.getName(), context));
+                                break;
+                            case VALUE_COUNT:
+                                builder.addAggregation(ValueCountAggregationBuilder.parse(aggregationOption.getName(), context));
+                                break;
+                            case GEO_CENTROID:
+                                builder.addAggregation(GeoCentroidAggregationBuilder.parse(aggregationOption.getName(), context));
+                                break;
+                            case GEO_DISTANCE:
+                                builder.addAggregation(GeoDistanceAggregationBuilder.parse(aggregationOption.getName(), context));
+                                break;
+                            case DATE_HISTOGRAM:
+                                builder.addAggregation(DateHistogramAggregationBuilder.parse(aggregationOption.getName(), context));
+                                break;
+                            case EXTENDED_STATS:
+                                builder.addAggregation(ExtendedStatsAggregationBuilder.parse(aggregationOption.getName(), context));
+                                break;
+                            case REVERSE_NESTED:
+                                builder.addAggregation(ReverseNestedAggregationBuilder.parse(aggregationOption.getName(), context));
+                                break;
+                            case DIVERSIFIED_SAMPLER:
+                                builder.addAggregation(DiversifiedAggregationBuilder.parse(aggregationOption.getName(), context));
+                                break;
+                            case SCRIPTED_METRIC:
+                                builder.addAggregation(ScriptedMetricAggregationBuilder.parse(aggregationOption.getName(), context));
+                                break;
+                            case PERCENTILE_RANKS:
+                                builder.addAggregation(PercentileRanksAggregationBuilder.parse(aggregationOption.getName(), context));
+                                break;
+                            default:
+                                break;
+                        }
+                    } catch (IOException ex) {
+                        System.out.println("Unable to parse the aggregations");
+                    }
+                });
             }
             if (!options.getSorts().isEmpty()) {
                 for (BaseSortOption baseSortOption : options.getSorts()) {
@@ -280,46 +397,38 @@ public class DefaultElasticSearchService implements InternalElasticSearchService
                             break;
                         case SCRIPT:
                             final ScriptSortOption scriptSortOption = (ScriptSortOption) baseSortOption;
-                            final Script script = new Script(scriptSortOption.getScript(), ScriptService.ScriptType.INLINE, scriptSortOption.getLang(), convertJsonObjectToMap(scriptSortOption.getParams()));
-                            final ScriptSortBuilder scriptSortBuilder = new ScriptSortBuilder(script, scriptSortOption.getType().getValue()).order(scriptSortOption.getOrder());
+                            final Script script = new Script(ScriptType.INLINE, scriptSortOption.getLang(), scriptSortOption.getScript(), convertJsonObjectToMap(scriptSortOption.getParams()));
+                            final ScriptSortBuilder scriptSortBuilder = new ScriptSortBuilder(script, ScriptSortBuilder.ScriptSortType.fromString(scriptSortOption.getType().getValue())).order(scriptSortOption.getOrder());
                             builder.addSort(scriptSortBuilder);
                             break;
                     }
                 }
             }
-            if (options.getExtraSource() != null) builder.setExtraSource(options.getExtraSource().encode());
-            if (options.getTemplateName() != null) {
-                if (options.getTemplateType() != null) {
-                    Map<String, Object> params = (options.getTemplateParams() == null ? null : options.getTemplateParams().getMap());
-                    builder.setTemplate(new Template(options.getTemplateName(), options.getTemplateType(), null, null, params));
-                } else {
-                    builder.setTemplate(new Template(options.getTemplateName()));
-                }
-            }
+
             if (!options.getScriptFields().isEmpty()) {
-                options.getScriptFields().entrySet().forEach(scriptFieldEntry -> {
-                    final Script script = new Script(scriptFieldEntry.getValue().getScript(), ScriptService.ScriptType.INLINE, scriptFieldEntry.getValue().getLang(), convertJsonObjectToMap(scriptFieldEntry.getValue().getParams()));
-                    builder.addScriptField(scriptFieldEntry.getKey(), script);
+                options.getScriptFields().forEach((scriptName, scriptValue) -> {
+                    final Script script = new Script(ScriptType.INLINE, scriptValue.getLang(), scriptValue.getScript(), convertJsonObjectToMap(scriptValue.getParams()));
+                    builder.addScriptField(scriptName, script);
                 });
             }
+
+            builder.execute(new ActionListener<SearchResponse>() {
+                @Override
+                public void onResponse(SearchResponse searchResponse) {
+                    resultHandler.handle(Future.succeededFuture(mapToSearchResponse(searchResponse)));
+                }
+
+                @Override
+                public void onFailure(Exception t) {
+                    handleFailure(resultHandler, t);
+                }
+            });
         }
-
-        builder.execute(new ActionListener<SearchResponse>() {
-            @Override
-            public void onResponse(SearchResponse searchResponse) {
-                resultHandler.handle(Future.succeededFuture(mapToSearchResponse(searchResponse)));
-            }
-
-            @Override
-            public void onFailure(Throwable t) {
-                handleFailure(resultHandler, t);
-            }
-        });
     }
+
 
     @Override
     public void searchScroll(String scrollId, SearchScrollOptions options, Handler<AsyncResult<com.hubrick.vertx.elasticsearch.model.SearchResponse>> resultHandler) {
-
         SearchScrollRequestBuilder builder = client.prepareSearchScroll(scrollId);
 
         if (options != null) {
@@ -333,12 +442,12 @@ public class DefaultElasticSearchService implements InternalElasticSearchService
             }
 
             @Override
-            public void onFailure(Throwable t) {
+            public void onFailure(Exception t) {
                 handleFailure(resultHandler, t);
             }
         });
-
     }
+
 
     @Override
     public void delete(String index, String type, String id, DeleteOptions options, Handler<AsyncResult<com.hubrick.vertx.elasticsearch.model.DeleteResponse>> resultHandler) {
@@ -348,8 +457,8 @@ public class DefaultElasticSearchService implements InternalElasticSearchService
         if (options != null) {
             if (options.getRouting() != null) builder.setRouting(options.getRouting());
             if (options.getParent() != null) builder.setParent(options.getParent());
-            if (options.isRefresh() != null) builder.setRefresh(options.isRefresh());
-            if (options.getConsistencyLevel() != null) builder.setConsistencyLevel(options.getConsistencyLevel());
+            if (options.isRefresh() != null) builder.setRefreshPolicy(options.isRefresh() ? WriteRequest.RefreshPolicy.IMMEDIATE : WriteRequest.RefreshPolicy.NONE);
+            if (options.getWaitForActiveShard() != null) builder.setWaitForActiveShards(options.getWaitForActiveShard());
             if (options.getVersion() != null) builder.setVersion(options.getVersion());
             if (options.getVersionType() != null) builder.setVersionType(options.getVersionType());
             if (options.getTimeout() != null) builder.setTimeout(options.getTimeout());
@@ -362,84 +471,83 @@ public class DefaultElasticSearchService implements InternalElasticSearchService
             }
 
             @Override
-            public void onFailure(Throwable t) {
+            public void onFailure(Exception t) {
                 handleFailure(resultHandler, t);
             }
         });
 
     }
 
+
     @Override
     public void suggest(List<String> indices, SuggestOptions options, Handler<AsyncResult<com.hubrick.vertx.elasticsearch.model.SuggestResponse>> resultHandler) {
 
-        final SuggestRequestBuilder builder = client.prepareSuggest(indices.toArray(new String[indices.size()]));
+        final SearchRequestBuilder builder = client.prepareSearch(indices.toArray(new String[indices.size()]));
 
         if (options != null && !options.getSuggestions().isEmpty()) {
             for (Map.Entry<String, BaseSuggestOption> suggestOptionEntry : options.getSuggestions().entrySet()) {
                 switch (suggestOptionEntry.getValue().getSuggestionType()) {
                     case COMPLETION:
                         final CompletionSuggestOption completionSuggestOption = (CompletionSuggestOption) suggestOptionEntry.getValue();
-                        final CompletionSuggestionBuilder completionBuilder = new CompletionSuggestionBuilder(suggestOptionEntry.getKey());
+                        final CompletionSuggestionBuilder completionBuilder = new CompletionSuggestionBuilder(completionSuggestOption.getField());
                         if (completionSuggestOption.getText() != null) {
                             completionBuilder.text(completionSuggestOption.getText());
-                        }
-                        if (completionSuggestOption.getField() != null) {
-                            completionBuilder.field(completionSuggestOption.getField());
                         }
                         if (completionSuggestOption.getSize() != null) {
                             completionBuilder.size(completionSuggestOption.getSize());
                         }
 
-                        builder.addSuggestion(completionBuilder);
+                        builder.suggest(new SuggestBuilder().addSuggestion(suggestOptionEntry.getKey() , completionBuilder));
                         break;
                 }
             }
         }
 
-        builder.execute(new ActionListener<SuggestResponse>() {
+        builder.execute(new ActionListener<SearchResponse>() {
 
             @Override
-            public void onResponse(SuggestResponse suggestResponse) {
+            public void onResponse(SearchResponse suggestResponse) {
                 resultHandler.handle(Future.succeededFuture(mapToSuggestResponse(suggestResponse)));
             }
 
             @Override
-            public void onFailure(Throwable t) {
+            public void onFailure(Exception t) {
                 handleFailure(resultHandler, t);
             }
         });
-
     }
+
 
     @Override
     public void deleteByQuery(List<String> indices, JsonObject query, DeleteByQueryOptions options, Handler<AsyncResult<com.hubrick.vertx.elasticsearch.model.DeleteByQueryResponse>> resultHandler) {
-        final DeleteByQueryRequestBuilder deleteByQueryRequestBuilder = new DeleteByQueryRequestBuilder(client, DeleteByQueryAction.INSTANCE)
-                .setIndices(indices.toArray(new String[indices.size()]));
+        final DeleteByQueryRequestBuilder deleteByQueryRequestBuilder = new DeleteByQueryRequestBuilder(client, DeleteByQueryAction.INSTANCE);
 
+        deleteByQueryRequestBuilder.source(indices.toArray(new String[indices.size()]));
         if (query != null) {
-            deleteByQueryRequestBuilder.setSource("{\"query\": " + query.encode() + "}");
+            deleteByQueryRequestBuilder.source().setQuery(QueryBuilders.wrapperQuery("{\"query\": " + query.encode() + "}"));
         }
 
         if (options != null) {
             if (!options.getTypes().isEmpty()) {
-                deleteByQueryRequestBuilder.setTypes(options.getTypes().toArray(new String[options.getTypes().size()]));
+                deleteByQueryRequestBuilder.source().setTypes(options.getTypes().toArray(new String[options.getTypes().size()]));
             }
-            if (options.getTimeout() != null) deleteByQueryRequestBuilder.setTimeout(options.getTimeout());
-            if (options.getRouting() != null) deleteByQueryRequestBuilder.setRouting(options.getRouting());
+            if (options.getTimeout() != null) deleteByQueryRequestBuilder.source().setTimeout(TimeValue.parseTimeValue(options.getTimeout(), ""));
+            if (options.getRouting() != null) deleteByQueryRequestBuilder.source().setRouting(options.getRouting());
         }
 
-        deleteByQueryRequestBuilder.execute(new ActionListener<DeleteByQueryResponse>() {
+        deleteByQueryRequestBuilder.execute(new ActionListener<BulkByScrollResponse>() {
             @Override
-            public void onResponse(DeleteByQueryResponse deleteByQueryResponse) {
+            public void onResponse(BulkByScrollResponse deleteByQueryResponse) {
                 resultHandler.handle(Future.succeededFuture(mapToDeleteByQueryResponse(deleteByQueryResponse)));
             }
 
             @Override
-            public void onFailure(Throwable t) {
+            public void onFailure(Exception t) {
                 handleFailure(resultHandler, t);
             }
         });
     }
+
 
     @Override
     public TransportClient getClient() {

--- a/src/main/java/com/hubrick/vertx/elasticsearch/impl/DefaultElasticSearchService.java
+++ b/src/main/java/com/hubrick/vertx/elasticsearch/impl/DefaultElasticSearchService.java
@@ -53,6 +53,7 @@ import org.elasticsearch.index.reindex.DeleteByQueryAction;
 import org.elasticsearch.index.reindex.DeleteByQueryRequestBuilder;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptType;
+import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.adjacency.AdjacencyMatrixAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.filter.FilterAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.filters.FiltersAggregationBuilder;
@@ -288,108 +289,7 @@ public class DefaultElasticSearchService implements InternalElasticSearchService
 
             if (options.getAggregations() != null) {
                 options.getAggregations().forEach(aggregationOption -> {
-                    try {
-                        QueryParseContext context = new QueryParseContext(XContentType.JSON.xContent().createParser(NamedXContentRegistry.EMPTY, aggregationOption.getDefinition().encode()));
-                        switch (aggregationOption.getType()) {
-                            case TERMS:
-                                builder.addAggregation(TermsAggregationBuilder.parse(aggregationOption.getName(), context));
-                                break;
-                            case MAX:
-                                builder.addAggregation(MaxAggregationBuilder.parse(aggregationOption.getName(), context));
-                                break;
-                            case MIN:
-                                builder.addAggregation(MinAggregationBuilder.parse(aggregationOption.getName(), context));
-                                break;
-                            case ADJACENCY_MATRIX:
-                                builder.addAggregation(AdjacencyMatrixAggregationBuilder.getParser().parse(aggregationOption.getName(), context));
-                                break;
-                            case SUM:
-                                builder.addAggregation(SumAggregationBuilder.parse(aggregationOption.getName(), context));
-                                break;
-                            case RANGE:
-                                builder.addAggregation(RangeAggregationBuilder.parse(aggregationOption.getName(), context));
-                                break;
-                            case STATS:
-                                builder.addAggregation(StatsAggregationBuilder.parse(aggregationOption.getName(), context));
-                                break;
-                            case FILTER:
-                                builder.addAggregation(FilterAggregationBuilder.parse(aggregationOption.getName(), context));
-                                break;
-                            case GLOBAL:
-                                builder.addAggregation(GlobalAggregationBuilder.parse(aggregationOption.getName(), context));
-                                break;
-                            case NESTED:
-                                builder.addAggregation(NestedAggregationBuilder.parse(aggregationOption.getName(), context));
-                                break;
-                            case AVERAGE:
-                                builder.addAggregation(AvgAggregationBuilder.parse(aggregationOption.getName(), context));
-                                break;
-                            case FILTERS:
-                                builder.addAggregation(FiltersAggregationBuilder.parse(aggregationOption.getName(), context));
-                                break;
-                            case MISSING:
-                                builder.addAggregation(MissingAggregationBuilder.parse(aggregationOption.getName(), context));
-                                break;
-                            case SAMPLER:
-                                builder.addAggregation(SamplerAggregationBuilder.parse(aggregationOption.getName(), context));
-                                break;
-                            case GEO_GRID:
-                                builder.addAggregation(GeoGridAggregationBuilder.parse(aggregationOption.getName(), context));
-                                break;
-                            case IP_RANGE:
-                                builder.addAggregation(IpRangeAggregationBuilder.parse(aggregationOption.getName(), context));
-                                break;
-                            case TOP_HITS:
-                                builder.addAggregation(TopHitsAggregationBuilder.parse(aggregationOption.getName(), context));
-                                break;
-                            case HISTOGRAM:
-                                builder.addAggregation(HistogramAggregationBuilder.parse(aggregationOption.getName(), context));
-                                break;
-                            case DATE_RANGE:
-                                builder.addAggregation(DateRangeAggregationBuilder.parse(aggregationOption.getName(), context));
-                                break;
-                            case GEO_BOUNDS:
-                                builder.addAggregation(GeoBoundsAggregationBuilder.parse(aggregationOption.getName(), context));
-                                break;
-                            case CARDINALITY:
-                                builder.addAggregation(CardinalityAggregationBuilder.parse(aggregationOption.getName(), context));
-                                break;
-                            case PERCENTILES:
-                                builder.addAggregation(PercentilesAggregationBuilder.parse(aggregationOption.getName(), context));
-                                break;
-                            case VALUE_COUNT:
-                                builder.addAggregation(ValueCountAggregationBuilder.parse(aggregationOption.getName(), context));
-                                break;
-                            case GEO_CENTROID:
-                                builder.addAggregation(GeoCentroidAggregationBuilder.parse(aggregationOption.getName(), context));
-                                break;
-                            case GEO_DISTANCE:
-                                builder.addAggregation(GeoDistanceAggregationBuilder.parse(aggregationOption.getName(), context));
-                                break;
-                            case DATE_HISTOGRAM:
-                                builder.addAggregation(DateHistogramAggregationBuilder.parse(aggregationOption.getName(), context));
-                                break;
-                            case EXTENDED_STATS:
-                                builder.addAggregation(ExtendedStatsAggregationBuilder.parse(aggregationOption.getName(), context));
-                                break;
-                            case REVERSE_NESTED:
-                                builder.addAggregation(ReverseNestedAggregationBuilder.parse(aggregationOption.getName(), context));
-                                break;
-                            case DIVERSIFIED_SAMPLER:
-                                builder.addAggregation(DiversifiedAggregationBuilder.parse(aggregationOption.getName(), context));
-                                break;
-                            case SCRIPTED_METRIC:
-                                builder.addAggregation(ScriptedMetricAggregationBuilder.parse(aggregationOption.getName(), context));
-                                break;
-                            case PERCENTILE_RANKS:
-                                builder.addAggregation(PercentileRanksAggregationBuilder.parse(aggregationOption.getName(), context));
-                                break;
-                            default:
-                                break;
-                        }
-                    } catch (IOException ex) {
-                        System.out.println("Unable to parse the aggregations");
-                    }
+                   builder.addAggregation(parseAggregation(aggregationOption));
                 });
             }
             if (!options.getSorts().isEmpty()) {
@@ -599,6 +499,124 @@ public class DefaultElasticSearchService implements InternalElasticSearchService
         }
 
         return list;
+    }
+
+    /**
+     * Convert recursively an AggregationOption in AggregationBuilder
+     * @param aggregationOption the aggregation option to parse
+     * @return the created aggregation builder if everything has been parsed correctly
+     */
+    private AggregationBuilder parseAggregation(AggregationOption aggregationOption) {
+        try {
+            AggregationBuilder result = null;
+            QueryParseContext context = new QueryParseContext(XContentType.JSON.xContent().createParser(NamedXContentRegistry.EMPTY, aggregationOption.getDefinition().encode())); 
+            switch (aggregationOption.getType()) {
+                case TERMS:
+                    result = TermsAggregationBuilder.parse(aggregationOption.getName(), context);
+                    break;
+                case MAX:
+                    result = MaxAggregationBuilder.parse(aggregationOption.getName(), context);
+                    break;
+                case MIN:
+                    result = MinAggregationBuilder.parse(aggregationOption.getName(), context);
+                    break;
+                case ADJACENCY_MATRIX:
+                    result = AdjacencyMatrixAggregationBuilder.getParser().parse(aggregationOption.getName(), context);
+                    break;
+                case SUM:
+                    result = SumAggregationBuilder.parse(aggregationOption.getName(), context);
+                    break;
+                case RANGE:
+                    result = RangeAggregationBuilder.parse(aggregationOption.getName(), context);
+                    break;
+                case STATS:
+                    result = StatsAggregationBuilder.parse(aggregationOption.getName(), context);
+                    break;
+                case FILTER:
+                    result = FilterAggregationBuilder.parse(aggregationOption.getName(), context);
+                    break;
+                case GLOBAL:
+                    result = GlobalAggregationBuilder.parse(aggregationOption.getName(), context);
+                    break;
+                case NESTED:
+                    result = NestedAggregationBuilder.parse(aggregationOption.getName(), context);
+                    break;
+                case AVERAGE:
+                    result = AvgAggregationBuilder.parse(aggregationOption.getName(), context);
+                    break;
+                case FILTERS:
+                    result = FiltersAggregationBuilder.parse(aggregationOption.getName(), context);
+                    break;
+                case MISSING:
+                    result = MissingAggregationBuilder.parse(aggregationOption.getName(), context);
+                    break;
+                case SAMPLER:
+                    result = SamplerAggregationBuilder.parse(aggregationOption.getName(), context);
+                    break;
+                case GEO_GRID:
+                    result = GeoGridAggregationBuilder.parse(aggregationOption.getName(), context);
+                    break;
+                case IP_RANGE:
+                    result = IpRangeAggregationBuilder.parse(aggregationOption.getName(), context);
+                    break;
+                case TOP_HITS:
+                    result = TopHitsAggregationBuilder.parse(aggregationOption.getName(), context);
+                    break;
+                case HISTOGRAM:
+                    result = HistogramAggregationBuilder.parse(aggregationOption.getName(), context);
+                    break;
+                case DATE_RANGE:
+                    result = DateRangeAggregationBuilder.parse(aggregationOption.getName(), context);
+                    break;
+                case GEO_BOUNDS:
+                    result = GeoBoundsAggregationBuilder.parse(aggregationOption.getName(), context);
+                    break;
+                case CARDINALITY:
+                    result = CardinalityAggregationBuilder.parse(aggregationOption.getName(), context);
+                    break;
+                case PERCENTILES:
+                    result = PercentilesAggregationBuilder.parse(aggregationOption.getName(), context);
+                    break;
+                case VALUE_COUNT:
+                    result = ValueCountAggregationBuilder.parse(aggregationOption.getName(), context);
+                    break;
+                case GEO_CENTROID:
+                    result = GeoCentroidAggregationBuilder.parse(aggregationOption.getName(), context);
+                    break;
+                case GEO_DISTANCE:
+                    result = GeoDistanceAggregationBuilder.parse(aggregationOption.getName(), context);
+                    break;
+                case DATE_HISTOGRAM:
+                    result = DateHistogramAggregationBuilder.parse(aggregationOption.getName(), context);
+                    break;
+                case EXTENDED_STATS:
+                    result = ExtendedStatsAggregationBuilder.parse(aggregationOption.getName(), context);
+                    break;
+                case REVERSE_NESTED:
+                    result = ReverseNestedAggregationBuilder.parse(aggregationOption.getName(), context);
+                    break;
+                case DIVERSIFIED_SAMPLER:
+                    result = DiversifiedAggregationBuilder.parse(aggregationOption.getName(), context);
+                    break;
+                case SCRIPTED_METRIC:
+                    result = ScriptedMetricAggregationBuilder.parse(aggregationOption.getName(), context);
+                    break;
+                case PERCENTILE_RANKS:
+                    result = PercentileRanksAggregationBuilder.parse(aggregationOption.getName(), context); 
+                    break;
+                default:
+                    throw new IllegalArgumentException("Unknown aggregation type " + aggregationOption.getType());
+            }
+            for (AggregationOption subAggregation : aggregationOption.getSubAggregations()) {
+                result.subAggregation(parseAggregation(subAggregation));
+            }
+
+            return result;
+        } catch (IOException ex) {
+            System.out.println("Unable to parse the aggregations");
+            throw new IllegalArgumentException("Wrong aggregation definition " + aggregationOption.getDefinition());
+        }
+
     }
 
 }

--- a/src/main/java/com/hubrick/vertx/elasticsearch/impl/DefaultElasticSearchService.java
+++ b/src/main/java/com/hubrick/vertx/elasticsearch/impl/DefaultElasticSearchService.java
@@ -92,10 +92,7 @@ import org.elasticsearch.search.suggest.completion.CompletionSuggestionBuilder;
 import javax.inject.Inject;
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static com.hubrick.vertx.elasticsearch.impl.ElasticSearchServiceMapper.*;
 
@@ -280,8 +277,15 @@ public class DefaultElasticSearchService implements InternalElasticSearchService
             if (options.isExplain() != null) builder.setExplain(options.isExplain());
             if (options.isVersion() != null) builder.setVersion(options.isVersion());
             if (options.isFetchSource() != null) builder.setFetchSource(options.isFetchSource());
-            if (!options.getFields().isEmpty()) options.getFields().forEach(builder::addStoredField);
             if (options.isTrackScores() != null) builder.setTrackScores(options.isTrackScores());
+
+            if (!options.getSourceIncludes().isEmpty() || !options.getSourceExcludes().isEmpty()) {
+                builder.setFetchSource(
+                        options.getSourceIncludes().toArray(new String[options.getSourceIncludes().size()]),
+                        options.getSourceExcludes().toArray(new String[options.getSourceExcludes().size()])
+                );
+            }
+
             if (options.getAggregations() != null) {
                 options.getAggregations().forEach(aggregationOption -> {
                     try {

--- a/src/main/java/com/hubrick/vertx/elasticsearch/impl/DefaultTransportClientFactory.java
+++ b/src/main/java/com/hubrick/vertx/elasticsearch/impl/DefaultTransportClientFactory.java
@@ -18,7 +18,7 @@ package com.hubrick.vertx.elasticsearch.impl;
 import com.hubrick.vertx.elasticsearch.TransportClientFactory;
 import org.elasticsearch.client.transport.TransportClient;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.plugin.deletebyquery.DeleteByQueryPlugin;
+import org.elasticsearch.transport.client.PreBuiltTransportClient;
 
 /**
  * Default implementation of {@link TransportClientFactory}
@@ -32,6 +32,6 @@ public class DefaultTransportClientFactory implements TransportClientFactory {
      */
     @Override
     public TransportClient create(Settings settings) {
-        return TransportClient.builder().addPlugin(DeleteByQueryPlugin.class).settings(settings).build();
+        return new PreBuiltTransportClient(settings);
     }
 }

--- a/src/main/java/com/hubrick/vertx/elasticsearch/impl/JsonElasticSearchConfigurator.java
+++ b/src/main/java/com/hubrick/vertx/elasticsearch/impl/JsonElasticSearchConfigurator.java
@@ -35,13 +35,11 @@ public class JsonElasticSearchConfigurator implements ElasticSearchConfigurator 
     protected String clusterName;
     protected boolean clientTransportSniff;
     protected final List<TransportAddress> transportAddresses = new ArrayList<>();
-    protected boolean requireUnits;
 
     public static final String CONFIG_NAME = "elasticsearch";
     public static final String CONFIG_TRANSPORT_ADDRESSES = "transportAddresses";
     public static final String CONFIG_HOSTNAME = "hostname";
     public static final String CONFIG_PORT = "port";
-    public static final String CONFIG_REQUIRE_UNITS = "requireUnits";
 
     @Inject
     public JsonElasticSearchConfigurator(Vertx vertx) {
@@ -64,7 +62,6 @@ public class JsonElasticSearchConfigurator implements ElasticSearchConfigurator 
         initClusterName(config);
         initClientTransportSniff(config);
         initTransportAddresses(config);
-        initRequireUnits(config);
     }
 
     protected void initClusterName(JsonObject config) {
@@ -97,10 +94,6 @@ public class JsonElasticSearchConfigurator implements ElasticSearchConfigurator 
 
     }
 
-    protected void initRequireUnits(JsonObject config) {
-        requireUnits = config.getBoolean(CONFIG_REQUIRE_UNITS, false);
-    }
-
     @Override
     public String getClusterName() {
         return clusterName;
@@ -109,11 +102,6 @@ public class JsonElasticSearchConfigurator implements ElasticSearchConfigurator 
     @Override
     public boolean getClientTransportSniff() {
         return clientTransportSniff;
-    }
-
-    @Override
-    public boolean getSettingsRequireUnits() {
-        return false;
     }
 
     @Override

--- a/src/main/java/com/hubrick/vertx/elasticsearch/model/AbstractWriteOptions.java
+++ b/src/main/java/com/hubrick/vertx/elasticsearch/model/AbstractWriteOptions.java
@@ -16,17 +16,16 @@
 package com.hubrick.vertx.elasticsearch.model;
 
 import io.vertx.core.json.JsonObject;
-import org.elasticsearch.action.WriteConsistencyLevel;
 
 /**
  * Abstract options
  */
 public abstract class AbstractWriteOptions<T extends AbstractWriteOptions<T>> extends AbstractOptions<T> {
 
-    private WriteConsistencyLevel consistencyLevel;
+    private Integer waitForActiveShard;
     private String timeout;
 
-    public static final String FIELD_CONSISTENCY_LEVEL = "consistencyLevel";
+    public static final String FIELD_WAIT_FOR_ACTIVE_SHARD = "waitForActiveShard";
     public static final String FIELD_TIMEOUT = "timeout";
 
     protected AbstractWriteOptions() {
@@ -34,7 +33,7 @@ public abstract class AbstractWriteOptions<T extends AbstractWriteOptions<T>> ex
 
     protected AbstractWriteOptions(T other) {
         super(other);
-        consistencyLevel = other.getConsistencyLevel();
+        waitForActiveShard = other.getWaitForActiveShard();
         timeout = other.getTimeout();
     }
 
@@ -43,17 +42,17 @@ public abstract class AbstractWriteOptions<T extends AbstractWriteOptions<T>> ex
 
         timeout = json.getString(FIELD_TIMEOUT);
 
-        String s = json.getString(FIELD_CONSISTENCY_LEVEL);
-        if (s != null) consistencyLevel = WriteConsistencyLevel.fromString(s);
+        String s = json.getString(FIELD_WAIT_FOR_ACTIVE_SHARD);
+        if (s != null) waitForActiveShard = Integer.valueOf(s);
 
     }
 
-    public WriteConsistencyLevel getConsistencyLevel() {
-        return consistencyLevel;
+    public Integer getWaitForActiveShard() {
+        return waitForActiveShard;
     }
 
-    public T setConsistencyLevel(WriteConsistencyLevel consistencyLevel) {
-        this.consistencyLevel = consistencyLevel;
+    public T setWaitForActiveShard(Integer waitForActiveShard) {
+        this.waitForActiveShard = waitForActiveShard;
         return returnThis();
     }
 
@@ -70,8 +69,8 @@ public abstract class AbstractWriteOptions<T extends AbstractWriteOptions<T>> ex
     public JsonObject toJson() {
         JsonObject json = super.toJson();
 
-        if (getConsistencyLevel() != null) {
-            json.put(FIELD_CONSISTENCY_LEVEL, getConsistencyLevel().toString().toLowerCase());
+        if (getWaitForActiveShard() != null) {
+            json.put(FIELD_WAIT_FOR_ACTIVE_SHARD, getWaitForActiveShard().toString());
         }
         if (getTimeout() != null) json.put(FIELD_TIMEOUT, getTimeout());
 

--- a/src/main/java/com/hubrick/vertx/elasticsearch/model/AggregationOption.java
+++ b/src/main/java/com/hubrick/vertx/elasticsearch/model/AggregationOption.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (C) 2016 Etaia AS (oss@hubrick.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hubrick.vertx.elasticsearch.model;
+
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Aggregation option
+ */
+@DataObject
+public class AggregationOption {
+    private String name;
+    private AggregationType type;
+    private JsonObject definition;
+
+    public static final String JSON_FIELD_NAME = "name";
+    public static final String JSON_FIELD_TYPE = "type";
+    public static final String JSON_FIELD_DEFINITION = "definition";
+
+    public AggregationOption() {
+    }
+
+    public AggregationOption(AggregationOption other) {
+        name = other.getName();
+        type = other.getType();
+        definition = other.getDefinition();
+    }
+
+    public AggregationOption(JsonObject json) {
+        name = json.getString(JSON_FIELD_NAME);
+        type = AggregationType.valueOf(json.getString(JSON_FIELD_TYPE));
+        definition = json.getJsonObject(JSON_FIELD_DEFINITION);
+    }
+
+    public enum AggregationType {
+        VALUE_COUNT, AVERAGE, MAX, MIN, SUM, STATS, EXTENDED_STATS,
+        FILTER, FILTERS, ADJACENCY_MATRIX, SAMPLER, DIVERSIFIED_SAMPLER,
+        GLOBAL, MISSING, NESTED, REVERSE_NESTED, GEO_DISTANCE, HISTOGRAM,
+        GEO_GRID, DATE_HISTOGRAM, RANGE, DATE_RANGE,
+        IP_RANGE, TERMS, PERCENTILES, PERCENTILE_RANKS, CARDINALITY,
+        TOP_HITS, GEO_BOUNDS, GEO_CENTROID, SCRIPTED_METRIC
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public AggregationOption setName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public AggregationType getType() {
+        return type;
+    }
+
+    public AggregationOption setType(AggregationType type) {
+        this.type = type;
+        return this;
+    }
+
+    public JsonObject getDefinition() {
+        return definition;
+    }
+
+    public AggregationOption setDefinition(JsonObject definition) {
+        this.definition = definition;
+        return this;
+    }
+
+    public JsonObject toJson() {
+        return new JsonObject()
+                .put(JSON_FIELD_NAME, name)
+                .put(JSON_FIELD_TYPE, type)
+                .put(JSON_FIELD_DEFINITION, definition);
+    }
+}

--- a/src/main/java/com/hubrick/vertx/elasticsearch/model/DeleteByQueryResponse.java
+++ b/src/main/java/com/hubrick/vertx/elasticsearch/model/DeleteByQueryResponse.java
@@ -16,24 +16,31 @@
 package com.hubrick.vertx.elasticsearch.model;
 
 import io.vertx.codegen.annotations.DataObject;
+import io.vertx.codegen.annotations.GenIgnore;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 @DataObject
 public class DeleteByQueryResponse extends AbstractRawResponse<DeleteByQueryResponse> {
 
-    private Long took;
+    private Long took; // in ms
     private Boolean timedOut;
-    private Long totalFound;
-    private Long totalDeleted;
-    private Long totalMissing;
-    private Long totalFailed;
+    private Long deleted;
+    private Integer batches;
+    private Long versionConflicts;
+    private Long retries;
+    private Long throttled; // in ms
+    private JsonArray failures = new JsonArray();
+
 
     public static final String JSON_FIELD_TOOK = "took";
     public static final String JSON_FIELD_TIMED_OUT = "timedOut";
-    public static final String JSON_FIELD_TOTAL_FOUND = "totalFound";
-    public static final String JSON_FIELD_TOTAL_DELETED = "totalDeleted";
-    public static final String JSON_FIELD_TOTAL_MISSING = "totalMissing";
-    public static final String JSON_FIELD_TOTAL_FAILED = "totalFailed";
+    public static final String JSON_FIELD_DELETED = "deleted";
+    public static final String JSON_FIELD_BATCHES = "batches";
+    public static final String JSON_FIELD_VERSION_CONFLICTS = "versionConflicts";
+    public static final String JSON_FIELD_RETRIES = "retries";
+    public static final String JSON_FIELD_THROTTLED = "throttled";
+    public static final String JSON_FIELD_FAILURES = "failures";
 
     public DeleteByQueryResponse() {
     }
@@ -43,9 +50,13 @@ public class DeleteByQueryResponse extends AbstractRawResponse<DeleteByQueryResp
 
         this.took = other.getTook();
         this.timedOut = other.getTimedOut();
-        this.totalFound = other.getTotalFound();
-        this.totalMissing = other.getTotalMissing();
-        this.totalFailed = other.getTotalFailed();
+        this.deleted = other.getDeleted();
+        this.batches = other.getBatches();
+        this.versionConflicts = other.getVersionConflicts();
+        this.retries = other.getRetries();
+        this.throttled = other.getThrottled();
+        this.failures = other.getFailures();
+
     }
 
     public DeleteByQueryResponse(JsonObject json) {
@@ -53,10 +64,12 @@ public class DeleteByQueryResponse extends AbstractRawResponse<DeleteByQueryResp
 
         this.took = json.getLong(JSON_FIELD_TOOK);
         this.timedOut = json.getBoolean(JSON_FIELD_TIMED_OUT);
-        this.totalFound = json.getLong(JSON_FIELD_TOTAL_FOUND);
-        this.totalDeleted = json.getLong(JSON_FIELD_TOTAL_DELETED);
-        this.totalMissing = json.getLong(JSON_FIELD_TOTAL_MISSING);
-        this.totalFailed = json.getLong(JSON_FIELD_TOTAL_FAILED);
+        this.deleted = json.getLong(JSON_FIELD_DELETED);
+        this.batches = json.getInteger(JSON_FIELD_BATCHES);
+        this.versionConflicts = json.getLong(JSON_FIELD_VERSION_CONFLICTS);
+        this.retries = json.getLong(JSON_FIELD_RETRIES);
+        this.throttled = json.getLong(JSON_FIELD_THROTTLED);
+        this.failures = json.getJsonArray(JSON_FIELD_FAILURES);
     }
 
     public Long getTook() {
@@ -77,39 +90,63 @@ public class DeleteByQueryResponse extends AbstractRawResponse<DeleteByQueryResp
         return this;
     }
 
-    public Long getTotalFound() {
-        return totalFound;
+    public Long getDeleted() {
+        return deleted;
     }
 
-    public DeleteByQueryResponse setTotalFound(Long totalFound) {
-        this.totalFound = totalFound;
+    public DeleteByQueryResponse setDeleted(Long deleted) {
+        this.deleted = deleted;
         return this;
     }
 
-    public Long getTotalDeleted() {
-        return totalDeleted;
+    public Integer getBatches() {
+        return batches;
     }
 
-    public DeleteByQueryResponse setTotalDeleted(Long totalDeleted) {
-        this.totalDeleted = totalDeleted;
+    public DeleteByQueryResponse setBatches(Integer batches) {
+        this.batches = batches;
         return this;
     }
 
-    public Long getTotalMissing() {
-        return totalMissing;
+    public Long getVersionConflicts() {
+        return versionConflicts;
     }
 
-    public DeleteByQueryResponse setTotalMissing(Long totalMissing) {
-        this.totalMissing = totalMissing;
+    public DeleteByQueryResponse setVersionConflicts(Long versionConflicts) {
+        this.versionConflicts = versionConflicts;
         return this;
     }
 
-    public Long getTotalFailed() {
-        return totalFailed;
+    public Long getRetries() {
+        return retries;
     }
 
-    public DeleteByQueryResponse setTotalFailed(Long totalFailed) {
-        this.totalFailed = totalFailed;
+    public DeleteByQueryResponse setRetries(Long retries) {
+        this.retries = retries;
+        return this;
+    }
+
+    public Long getThrottled() {
+        return throttled;
+    }
+
+    public DeleteByQueryResponse setThrottled(Long throttled) {
+        this.throttled = throttled;
+        return this;
+    }
+
+    public JsonArray getFailures() {
+        return failures;
+    }
+
+    @GenIgnore
+    public DeleteByQueryResponse addFailure(JsonObject failure) {
+        this.failures.add(failure);
+        return this;
+    }
+
+    public DeleteByQueryResponse setFailures(JsonArray failures) {
+        this.failures = failures;
         return this;
     }
 
@@ -119,10 +156,12 @@ public class DeleteByQueryResponse extends AbstractRawResponse<DeleteByQueryResp
 
         if (took != null) json.put(JSON_FIELD_TOOK, took);
         if (timedOut != null) json.put(JSON_FIELD_TIMED_OUT, timedOut);
-        if (totalFound != null) json.put(JSON_FIELD_TOTAL_FOUND, totalFound);
-        if (totalDeleted != null) json.put(JSON_FIELD_TOTAL_DELETED, totalDeleted);
-        if (totalMissing != null) json.put(JSON_FIELD_TOTAL_MISSING, totalMissing);
-        if (totalFailed != null) json.put(JSON_FIELD_TOTAL_FAILED, totalFailed);
+        if (deleted != null) json.put(JSON_FIELD_DELETED, deleted);
+        if (batches != null) json.put(JSON_FIELD_BATCHES, batches);
+        if (versionConflicts != null) json.put(JSON_FIELD_VERSION_CONFLICTS, versionConflicts);
+        if (retries != null) json.put(JSON_FIELD_RETRIES, retries);
+        if (throttled != null) json.put(JSON_FIELD_THROTTLED, throttled);
+        if (failures != null) json.put(JSON_FIELD_FAILURES, failures);
 
         return json.mergeIn(super.toJson());
     }

--- a/src/main/java/com/hubrick/vertx/elasticsearch/model/GetOptions.java
+++ b/src/main/java/com/hubrick/vertx/elasticsearch/model/GetOptions.java
@@ -33,18 +33,14 @@ public class GetOptions extends AbstractOptions<GetOptions> {
     private Boolean fetchSource;
     private List<String> fetchSourceIncludes = new ArrayList<>();
     private List<String> fetchSourceExcludes = new ArrayList<>();
-    private Boolean transformSource;
     private Boolean realtime;
-    private Boolean ignoreErrorsOnGeneratedFields;
 
     public static final String FIELD_PREFERENCE = "preference";
     public static final String FIELD_FIELDS = "fields";
     public static final String FIELD_FETCH_SOURCE = "fetchSource";
     public static final String FIELD_FETCH_SOURCE_INCLUDES = "fetchSourceIncludes";
     public static final String FIELD_FETCH_SOURCE_EXCLUDES = "fetchSourceExcludes";
-    public static final String FIELD_TRANSFORM_SOURCE = "transformSource";
     public static final String FIELD_REALTIME = "realtime";
-    public static final String FIELD_IGNORE_ERROR_ON_GENERATED_FIELDS = "ignoreErrorsOnGeneratedFields";
 
     public GetOptions() {
     }
@@ -57,9 +53,7 @@ public class GetOptions extends AbstractOptions<GetOptions> {
         fetchSource = other.isFetchSource();
         fetchSourceIncludes = other.getFetchSourceIncludes();
         fetchSourceExcludes = other.getFetchSourceExcludes();
-        transformSource = other.isTransformSource();
         realtime = other.isRealtime();
-        ignoreErrorsOnGeneratedFields = other.isIgnoreErrorsOnGeneratedFields();
     }
 
     public GetOptions(JsonObject json) {
@@ -70,9 +64,7 @@ public class GetOptions extends AbstractOptions<GetOptions> {
         fetchSource = json.getBoolean(FIELD_FETCH_SOURCE);
         fetchSourceIncludes = json.getJsonArray(FIELD_FETCH_SOURCE_INCLUDES, new JsonArray()).getList();
         fetchSourceExcludes = json.getJsonArray(FIELD_FETCH_SOURCE_EXCLUDES, new JsonArray()).getList();
-        transformSource = json.getBoolean(FIELD_TRANSFORM_SOURCE);
         realtime = json.getBoolean(FIELD_REALTIME);
-        ignoreErrorsOnGeneratedFields = json.getBoolean(FIELD_IGNORE_ERROR_ON_GENERATED_FIELDS);
 
     }
 
@@ -125,30 +117,12 @@ public class GetOptions extends AbstractOptions<GetOptions> {
         return this;
     }
 
-    public Boolean isTransformSource() {
-        return transformSource;
-    }
-
-    public GetOptions setTransformSource(Boolean transformSource) {
-        this.transformSource = transformSource;
-        return this;
-    }
-
     public Boolean isRealtime() {
         return realtime;
     }
 
     public GetOptions setRealtime(Boolean realtime) {
         this.realtime = realtime;
-        return this;
-    }
-
-    public Boolean isIgnoreErrorsOnGeneratedFields() {
-        return ignoreErrorsOnGeneratedFields;
-    }
-
-    public GetOptions setIgnoreErrorsOnGeneratedFields(Boolean ignoreErrorsOnGeneratedFields) {
-        this.ignoreErrorsOnGeneratedFields = ignoreErrorsOnGeneratedFields;
         return this;
     }
 
@@ -161,9 +135,7 @@ public class GetOptions extends AbstractOptions<GetOptions> {
         if (isFetchSource() != null) json.put(FIELD_FETCH_SOURCE, isFetchSource());
         if (!getFetchSourceIncludes().isEmpty()) json.put(FIELD_FETCH_SOURCE_INCLUDES, new JsonArray(getFetchSourceIncludes()));
         if (!getFetchSourceExcludes().isEmpty()) json.put(FIELD_FETCH_SOURCE_EXCLUDES, new JsonArray(getFetchSourceExcludes()));
-        if (isTransformSource() != null) json.put(FIELD_TRANSFORM_SOURCE, isTransformSource());
         if (isRealtime() != null) json.put(FIELD_REALTIME, isRealtime());
-        if (isIgnoreErrorsOnGeneratedFields() != null) json.put(FIELD_IGNORE_ERROR_ON_GENERATED_FIELDS, isIgnoreErrorsOnGeneratedFields());
 
         return json;
     }

--- a/src/main/java/com/hubrick/vertx/elasticsearch/model/SearchOptions.java
+++ b/src/main/java/com/hubrick/vertx/elasticsearch/model/SearchOptions.java
@@ -15,13 +15,11 @@
  */
 package com.hubrick.vertx.elasticsearch.model;
 
-import com.google.common.base.Strings;
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.elasticsearch.action.search.SearchType;
-import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.sort.SortOrder;
 
 import java.util.ArrayList;
@@ -50,7 +48,8 @@ public class SearchOptions {
     private Boolean explain;
     private Boolean version;
     private Boolean fetchSource;
-    private List<String> fields = new ArrayList<>();
+    private List<String> sourceIncludes = new ArrayList<>();
+    private List<String> sourceExcludes = new ArrayList<>();
     private Boolean trackScores;
     private List<AggregationOption> aggregations = new ArrayList<>();
     private List<BaseSortOption> sorts = new ArrayList<>();
@@ -71,7 +70,8 @@ public class SearchOptions {
     public static final String JSON_FIELD_EXPLAIN = "explain";
     public static final String JSON_FIELD_VERSION = "version";
     public static final String JSON_FIELD_FETCH_SOURCE = "fetchSource";
-    public static final String JSON_FIELD_FIELDS = "fields";
+    public static final String JSON_FIELD_SOURCE_INCLUDES = "sourceIncludes";
+    public static final String JSON_FIELD_SOURCE_EXCLUDES = "sourceExcludes";
     public static final String JSON_FIELD_TRACK_SCORES = "trackScores";
     public static final String JSON_FIELD_AGGREGATIONS = "aggregations";
     public static final String JSON_FIELD_SORTS = "sorts";
@@ -96,7 +96,8 @@ public class SearchOptions {
         explain = other.isExplain();
         version = other.isVersion();
         fetchSource = other.isFetchSource();
-        fields = other.getFields();
+        sourceIncludes = other.getSourceIncludes();
+        sourceExcludes = other.getSourceExcludes();
         trackScores = other.isTrackScores();
         aggregations = other.getAggregations();
         sorts = other.getSorts();
@@ -119,7 +120,8 @@ public class SearchOptions {
         explain = json.getBoolean(JSON_FIELD_EXPLAIN);
         version = json.getBoolean(JSON_FIELD_VERSION);
         fetchSource = json.getBoolean(JSON_FIELD_FETCH_SOURCE);
-        fields = json.getJsonArray(JSON_FIELD_FIELDS, new JsonArray()).getList();
+        sourceIncludes = json.getJsonArray(JSON_FIELD_SOURCE_INCLUDES, new JsonArray()).getList();
+        sourceExcludes = json.getJsonArray(JSON_FIELD_SOURCE_EXCLUDES, new JsonArray()).getList();
         trackScores = json.getBoolean(JSON_FIELD_TRACK_SCORES);
 
         JsonArray aggregationsJson = json.getJsonArray(JSON_FIELD_AGGREGATIONS);
@@ -239,12 +241,21 @@ public class SearchOptions {
         return this;
     }
 
-    public List<String> getFields() {
-        return fields;
+    public List<String> getSourceIncludes() {
+        return sourceIncludes;
     }
 
-    public SearchOptions addField(String field) {
-        fields.add(field);
+    public SearchOptions setSourceIncludes(List<String> sourceIncludes) {
+        this.sourceIncludes = sourceIncludes;
+        return this;
+    }
+
+    public List<String> getSourceExcludes() {
+        return sourceExcludes;
+    }
+
+    public SearchOptions setSourceExcludes(List<String> sourceExcludes) {
+        this.sourceExcludes = sourceExcludes;
         return this;
     }
 
@@ -377,7 +388,8 @@ public class SearchOptions {
         if (explain != null) json.put(JSON_FIELD_EXPLAIN, explain);
         if (version != null) json.put(JSON_FIELD_VERSION, version);
         if (fetchSource != null) json.put(JSON_FIELD_FETCH_SOURCE, fetchSource);
-        if (!fields.isEmpty()) json.put(JSON_FIELD_FIELDS, new JsonArray(fields));
+        if (!sourceIncludes.isEmpty()) json.put(JSON_FIELD_SOURCE_INCLUDES, new JsonArray(sourceIncludes));
+        if (!sourceExcludes.isEmpty()) json.put(JSON_FIELD_SOURCE_EXCLUDES, new JsonArray(sourceExcludes));
         if (trackScores != null) json.put(JSON_FIELD_TRACK_SCORES, trackScores);
         if (explain != null) json.put(JSON_FIELD_EXPLAIN, explain);
 

--- a/src/main/java/com/hubrick/vertx/elasticsearch/model/SearchOptions.java
+++ b/src/main/java/com/hubrick/vertx/elasticsearch/model/SearchOptions.java
@@ -101,7 +101,7 @@ public class SearchOptions {
         trackScores = other.isTrackScores();
         aggregations = other.getAggregations();
         sorts = other.getSorts();
-        scriptFields = other.scriptFields;
+        scriptFields = other.getScriptFields();
     }
 
     public SearchOptions(JsonObject json) {

--- a/src/main/java/com/hubrick/vertx/elasticsearch/model/UpdateOptions.java
+++ b/src/main/java/com/hubrick/vertx/elasticsearch/model/UpdateOptions.java
@@ -18,7 +18,7 @@ package com.hubrick.vertx.elasticsearch.model;
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.script.ScriptType;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -30,7 +30,7 @@ import java.util.List;
 public class UpdateOptions extends AbstractWriteOptions<UpdateOptions> {
 
     private String script;
-    private ScriptService.ScriptType scriptType;
+    private ScriptType scriptType;
     private String scriptLang;
     private JsonObject scriptParams;
     private List<String> fields = new ArrayList<>();
@@ -54,7 +54,7 @@ public class UpdateOptions extends AbstractWriteOptions<UpdateOptions> {
     public static final String FIELD_SCRIPTED_UPSERT = "scriptedUpsert";
 
     private static final String SCRIPT_TYPE_INLINE = "inline";
-    private static final String SCRIPT_TYPE_INDEXED = "indexed";
+    private static final String SCRIPT_TYPE_STORED = "stored";
     private static final String SCRIPT_TYPE_FILE = "file";
 
     public UpdateOptions() {
@@ -96,13 +96,13 @@ public class UpdateOptions extends AbstractWriteOptions<UpdateOptions> {
         if (s != null) {
             switch (s) {
                 case SCRIPT_TYPE_INLINE:
-                    scriptType = ScriptService.ScriptType.INLINE;
+                    scriptType = ScriptType.INLINE;
                     break;
-                case SCRIPT_TYPE_INDEXED:
-                    scriptType = ScriptService.ScriptType.INDEXED;
+                case SCRIPT_TYPE_STORED:
+                    scriptType = ScriptType.STORED;
                     break;
                 case SCRIPT_TYPE_FILE:
-                    scriptType = ScriptService.ScriptType.FILE;
+                    scriptType = ScriptType.FILE;
                     break;
                 default:
                     throw new IllegalArgumentException("Unsupported script type: " + s);
@@ -114,13 +114,13 @@ public class UpdateOptions extends AbstractWriteOptions<UpdateOptions> {
         return script;
     }
 
-    public UpdateOptions setScript(String script, ScriptService.ScriptType scriptType) {
+    public UpdateOptions setScript(String script, ScriptType scriptType) {
         this.script = script;
         this.scriptType = scriptType;
         return this;
     }
 
-    public ScriptService.ScriptType getScriptType() {
+    public ScriptType getScriptType() {
         return scriptType;
     }
 

--- a/src/test/java/com/hubrick/vertx/elasticsearch/DeleteOptionsTest.java
+++ b/src/test/java/com/hubrick/vertx/elasticsearch/DeleteOptionsTest.java
@@ -17,7 +17,6 @@ package com.hubrick.vertx.elasticsearch;
 
 import com.hubrick.vertx.elasticsearch.model.DeleteOptions;
 import io.vertx.core.json.JsonObject;
-import org.elasticsearch.action.WriteConsistencyLevel;
 import org.elasticsearch.index.VersionType;
 import org.junit.Test;
 
@@ -38,7 +37,6 @@ public class DeleteOptionsTest {
         assertEquals("{\"parent\":\"parent\"}", json1.encode());
 
         options1 = new DeleteOptions()
-                .setConsistencyLevel(WriteConsistencyLevel.ALL)
                 .setParent("parent")
                 .setRefresh(true)
                 .setRouting("routing")
@@ -48,7 +46,7 @@ public class DeleteOptionsTest {
 
         json1 = options1.toJson();
 
-        assertEquals(7, json1.fieldNames().size());
+        assertEquals(6, json1.fieldNames().size());
 
         DeleteOptions options2 = new DeleteOptions(json1);
         JsonObject json2 = options2.toJson();

--- a/src/test/java/com/hubrick/vertx/elasticsearch/GetOptionsTest.java
+++ b/src/test/java/com/hubrick/vertx/elasticsearch/GetOptionsTest.java
@@ -44,13 +44,11 @@ public class GetOptionsTest {
                 .addField("field2")
                 .setFetchSource(true)
                 .setFetchSource(Arrays.asList("incl1", "incl2"), Arrays.asList("excl1", "excl2"))
-                .setTransformSource(true)
-                .setRealtime(true)
-                .setIgnoreErrorsOnGeneratedFields(true);
+                .setRealtime(true);
 
         json1= options1.toJson();
 
-        assertEquals(8, json1.fieldNames().size());
+        assertEquals(6, json1.fieldNames().size());
 
         GetOptions options2 = new GetOptions(json1);
         JsonObject json2 = options2.toJson();

--- a/src/test/java/com/hubrick/vertx/elasticsearch/IndexOptionsTest.java
+++ b/src/test/java/com/hubrick/vertx/elasticsearch/IndexOptionsTest.java
@@ -17,7 +17,6 @@ package com.hubrick.vertx.elasticsearch;
 
 import com.hubrick.vertx.elasticsearch.model.IndexOptions;
 import io.vertx.core.json.JsonObject;
-import org.elasticsearch.action.WriteConsistencyLevel;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.index.VersionType;
 import org.junit.Test;
@@ -48,7 +47,6 @@ public class IndexOptionsTest {
                 .setParent("parent")
                 .setOpType(IndexRequest.OpType.CREATE)
                 .setRefresh(true)
-                .setConsistencyLevel(WriteConsistencyLevel.ALL)
                 .setVersion(2L)
                 .setVersionType(VersionType.EXTERNAL)
                 .setTimestamp("timestamp")
@@ -56,7 +54,7 @@ public class IndexOptionsTest {
                 .setTimeout("timeout");
 
         json1 = options1.toJson();
-        assertEquals(11, json1.fieldNames().size());
+        assertEquals(10, json1.fieldNames().size());
 
         options2 = new IndexOptions(json1);
         json2 = options2.toJson();

--- a/src/test/java/com/hubrick/vertx/elasticsearch/SearchOptionsTest.java
+++ b/src/test/java/com/hubrick/vertx/elasticsearch/SearchOptionsTest.java
@@ -23,6 +23,8 @@ import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.search.sort.SortOrder;
 import org.junit.Test;
 
+import java.util.Arrays;
+
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -55,8 +57,7 @@ public class SearchOptionsTest {
                 .setExplain(true)
                 .setVersion(true)
                 .setFetchSource(true)
-                .addField("field1")
-                .addField("field2")
+                .setSourceIncludes(Arrays.asList("field1", "field2"))
                 .setTrackScores(true)
                 //.addAggregation(AggregationBuilders.terms("name"))
                 .addFieldSort("status", SortOrder.ASC)

--- a/src/test/java/com/hubrick/vertx/elasticsearch/SearchOptionsTest.java
+++ b/src/test/java/com/hubrick/vertx/elasticsearch/SearchOptionsTest.java
@@ -20,13 +20,10 @@ import com.hubrick.vertx.elasticsearch.model.ScriptSortOption;
 import com.hubrick.vertx.elasticsearch.model.SearchOptions;
 import io.vertx.core.json.JsonObject;
 import org.elasticsearch.action.search.SearchType;
-import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.sort.SortOrder;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
 
 /**
  * Unit tests for {@link SearchOptions}
@@ -44,7 +41,7 @@ public class SearchOptionsTest {
         options1 = new SearchOptions()
                 .addType("type1")
                 .addType("type2")
-                .setSearchType(SearchType.QUERY_AND_FETCH)
+                .setSearchType(SearchType.QUERY_THEN_FETCH)
                 .setScroll("scroll")
                 .setTimeout("timeout")
                 .setTerminateAfter(10)
@@ -61,15 +58,11 @@ public class SearchOptionsTest {
                 .addField("field1")
                 .addField("field2")
                 .setTrackScores(true)
-                .setAggregations(new JsonObject().put("name", "name"))
+                //.addAggregation(AggregationBuilders.terms("name"))
                 .addFieldSort("status", SortOrder.ASC)
                 .addFieldSort("insert_date", SortOrder.ASC)
                 .addScripSort("doc['score']", ScriptSortOption.Type.NUMBER, new JsonObject(), SortOrder.ASC)
-                .addScriptField("script_field", "doc['score']", new JsonObject().put("param1", ImmutableList.of("1", "2", "3")))
-                .setExtraSource(new JsonObject().put("extra", "1"))
-                .setTemplateName("templateName")
-                .setTemplateType(ScriptService.ScriptType.INDEXED)
-                .setTemplateParams(new JsonObject().put("template_param", "sample_param"));
+                .addScriptField("script_field", "doc['score']", new JsonObject().put("param1", ImmutableList.of("1", "2", "3")));
 
         json1 = options1.toJson();
 
@@ -82,36 +75,6 @@ public class SearchOptionsTest {
         json2 = options2.toJson();
 
         assertEquals(json1.encode(), json2.encode());
-    }
-
-    @Test
-    public void testSetTemplateTypeFromJson() {
-
-        JsonObject json = new JsonObject();
-
-        try {
-            json.put("templateType", "not-a-real-enum");
-            new SearchOptions(json);
-            fail("Expected exception");
-        } catch (IllegalArgumentException e) {
-            // Expected
-        }
-
-        json.put("templateType", "file");
-        SearchOptions options = new SearchOptions(json);
-        assertEquals(options.getTemplateType(), ScriptService.ScriptType.FILE);
-
-        json.put("templateType", "indexed");
-        options = new SearchOptions(json);
-        assertEquals(options.getTemplateType(), ScriptService.ScriptType.INDEXED);
-
-        json.put("templateType", "inline");
-        options = new SearchOptions(json);
-        assertEquals(options.getTemplateType(), ScriptService.ScriptType.INLINE);
-
-        json.remove("templateType");
-        options = new SearchOptions(json);
-        assertNull(options.getTemplateType());
     }
 
 }

--- a/src/test/java/com/hubrick/vertx/elasticsearch/UpdateOptionsTest.java
+++ b/src/test/java/com/hubrick/vertx/elasticsearch/UpdateOptionsTest.java
@@ -18,6 +18,7 @@ package com.hubrick.vertx.elasticsearch;
 import com.hubrick.vertx.elasticsearch.model.UpdateOptions;
 import io.vertx.core.json.JsonObject;
 import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.script.ScriptType;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -31,7 +32,7 @@ public class UpdateOptionsTest {
     public void testUpdateOptions() throws Exception {
 
         UpdateOptions options1 = new UpdateOptions()
-                .setScript("script", ScriptService.ScriptType.INLINE);
+                .setScript("script", ScriptType.INLINE);
 
         JsonObject json1 = options1.toJson();
         assertEquals(2, json1.fieldNames().size());
@@ -42,7 +43,7 @@ public class UpdateOptionsTest {
         assertEquals(json1.encode(), json2.encode());
 
         options1 = new UpdateOptions()
-                .setScript("script", ScriptService.ScriptType.INLINE)
+                .setScript("script", ScriptType.INLINE)
                 .setScriptLang("js")
                 .setScriptParams(new JsonObject().put("p1", "1").put("p2", 2))
                 .addField("field1")

--- a/src/test/java/com/hubrick/vertx/elasticsearch/integration/IntegrationTestBase.java
+++ b/src/test/java/com/hubrick/vertx/elasticsearch/integration/IntegrationTestBase.java
@@ -47,6 +47,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.junit.runners.MethodSorters;
 
 import java.util.Scanner;
@@ -201,7 +202,7 @@ public abstract class IntegrationTestBase extends AbstractVertxIntegrationTest {
 
         final Async async = testContext.async();
         SearchOptions options = new SearchOptions()
-                .setSearchType(SearchType.SCAN)
+                .setSearchType(SearchType.DEFAULT)
                 .setScroll("5m")
                 .setQuery(new JsonObject().put("match_all", new JsonObject()));
 
@@ -293,9 +294,9 @@ public abstract class IntegrationTestBase extends AbstractVertxIntegrationTest {
                 })
                 .subscribe(
                         deleteByQueryResponse -> {
-                            assertThat(testContext, deleteByQueryResponse.getTotalFound(), is(1l));
-                            assertThat(testContext, deleteByQueryResponse.getTotalDeleted(), is(1l));
-                            assertThat(testContext, deleteByQueryResponse.getTotalFailed(), is(0l));
+                            assertThat(testContext, deleteByQueryResponse.getTimedOut(), is(false));
+                            assertThat(testContext, deleteByQueryResponse.getDeleted(), is(1L));
+                            assertThat(testContext, deleteByQueryResponse.getFailures().size(), is(0));
 
                             async.complete();
                         },
@@ -314,7 +315,7 @@ public abstract class IntegrationTestBase extends AbstractVertxIntegrationTest {
                             assertThat(testContext, deleteResponse.getType(), is(type));
                             assertThat(testContext, deleteResponse.getId(), is(id));
                             assertThat(testContext, deleteResponse.getFound(), is(true));
-                            assertThat(testContext, deleteResponse.getVersion(), greaterThan(0l));
+                            assertThat(testContext, deleteResponse.getVersion(), greaterThan(0L));
 
                             async.complete();
                         },

--- a/src/test/java/com/hubrick/vertx/elasticsearch/integration/IntegrationTestBase.java
+++ b/src/test/java/com/hubrick/vertx/elasticsearch/integration/IntegrationTestBase.java
@@ -50,6 +50,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.MethodSorters;
 
+import java.util.Arrays;
 import java.util.Scanner;
 import java.util.UUID;
 
@@ -161,8 +162,7 @@ public abstract class IntegrationTestBase extends AbstractVertxIntegrationTest {
                 .setTimeout("1000")
                 .setSize(10)
                 .setFrom(10)
-                .addField("user")
-                .addField("message")
+                .setSourceIncludes(Arrays.asList("user", "message"))
                 .addFieldSort("user", SortOrder.DESC)
                 .addScripSort("doc['message']", ScriptSortOption.Type.STRING, new JsonObject().put("param1", ImmutableList.of("1", "2", "3")), SortOrder.ASC)
                 .addScriptField("script_field", "doc['message']", new JsonObject().put("param1", ImmutableList.of("1", "2", "3")))


### PR DESCRIPTION
I made some changes to comply with the ElasticSearch 5 API

(based mainly on https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking_50_java_api_changes.html)

Main parts : 
- Remove "deleteByQuery" plugin (as it's now in the API)
- Use different classes for aggregations (there is no global parser to read from Json, each aggregation type has its own parser)

I'm not sure all the tests succeeds (as I didn't manage to test with the docker part)