### PR TITLE
Implement search_after search option

### DIFF
--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -206,6 +206,7 @@
 |[[routing]]`routing`|`String`|-
 |[[scriptFields]]`scriptFields`|`link:dataobjects.html#ScriptFieldOption[ScriptFieldOption]`|-
 |[[scroll]]`scroll`|`String`|-
+|[[searchAfter]]`searchAfter`|`Json array`|-
 |[[searchType]]`searchType`|`link:enums.html#SearchType[SearchType]`|-
 |[[size]]`size`|`Number (Integer)`|-
 |[[slices]]`slices`|`Number (Integer)`|-
@@ -704,6 +705,7 @@
 |[[routing]]`routing`|`String`|-
 |[[scriptFields]]`scriptFields`|`link:dataobjects.html#ScriptFieldOption[ScriptFieldOption]`|-
 |[[scroll]]`scroll`|`String`|-
+|[[searchAfter]]`searchAfter`|`Json array`|-
 |[[searchType]]`searchType`|`link:enums.html#SearchType[SearchType]`|-
 |[[size]]`size`|`Number (Integer)`|-
 |[[sourceExcludes]]`sourceExcludes`|`Array of String`|-

--- a/src/main/java/com/hubrick/vertx/elasticsearch/impl/DefaultElasticSearchService.java
+++ b/src/main/java/com/hubrick/vertx/elasticsearch/impl/DefaultElasticSearchService.java
@@ -770,6 +770,10 @@ public class DefaultElasticSearchService implements InternalElasticSearchService
                     break;
             }
         }
+
+        if (options.hasSearchAfter()) {
+            builder.searchAfter(options.getSearchAfter().stream().toArray());
+        }
     }
 
     private Script createScript(Optional<com.hubrick.vertx.elasticsearch.model.ScriptType> type, Optional<String> lang, Optional<JsonObject> params, String script) {

--- a/src/main/java/com/hubrick/vertx/elasticsearch/model/AbstractSearchOptions.java
+++ b/src/main/java/com/hubrick/vertx/elasticsearch/model/AbstractSearchOptions.java
@@ -48,6 +48,7 @@ public abstract class AbstractSearchOptions<T extends AbstractSearchOptions<T>> 
     private Boolean fetchSource;
     private List<String> sourceIncludes = new ArrayList<>();
     private List<String> sourceExcludes = new ArrayList<>();
+    private JsonArray searchAfter = new JsonArray();
     private Boolean trackScores;
     private List<AggregationOption> aggregations = new ArrayList<>();
     private List<BaseSortOption> sorts = new ArrayList<>();
@@ -80,6 +81,7 @@ public abstract class AbstractSearchOptions<T extends AbstractSearchOptions<T>> 
     public static final String JSON_FIELD_STORED_FIELDS = "storedFields";
     public static final String JSON_FIELD_INDICES_OPTIONS = "indicesOptions";
     public static final String JSON_FIELD_SUGGESTIONS = "suggestions";
+    public static final String JSON_FIELD_SEARCH_AFTER = "searchAfter";
 
     public AbstractSearchOptions() {
     }
@@ -109,6 +111,7 @@ public abstract class AbstractSearchOptions<T extends AbstractSearchOptions<T>> 
         storedFields = other.getStoredFields();
         indicesOptions = other.getIndicesOptions();
         suggestions = other.getSuggestions();
+        searchAfter = other.getSearchAfter();
     }
 
     public AbstractSearchOptions(JsonObject json) {
@@ -132,6 +135,7 @@ public abstract class AbstractSearchOptions<T extends AbstractSearchOptions<T>> 
         trackScores = json.getBoolean(JSON_FIELD_TRACK_SCORES);
         storedFields = json.getJsonArray(JSON_FIELD_STORED_FIELDS, new JsonArray()).getList();
         indicesOptions = Optional.ofNullable(json.getJsonObject(JSON_FIELD_INDICES_OPTIONS)).map(IndicesOptions::new).orElse(null);
+        searchAfter = json.getJsonArray(JSON_FIELD_SEARCH_AFTER);
 
         JsonArray aggregationsJson = json.getJsonArray(JSON_FIELD_AGGREGATIONS);
         if (aggregationsJson != null) {
@@ -418,6 +422,20 @@ public abstract class AbstractSearchOptions<T extends AbstractSearchOptions<T>> 
         return returnThis();
     }
 
+    public JsonArray getSearchAfter() {
+        return searchAfter;
+    }
+
+    public T setSearchAfter(JsonArray searchAfter) {
+        this.searchAfter = searchAfter;
+        return returnThis();
+    }
+
+    @GenIgnore
+    public boolean hasSearchAfter() {
+        return this.searchAfter != null && !this.searchAfter.isEmpty();
+    }
+    
     public JsonObject toJson() {
 
         final JsonObject json = new JsonObject();
@@ -472,6 +490,10 @@ public abstract class AbstractSearchOptions<T extends AbstractSearchOptions<T>> 
             json.put(JSON_FIELD_SUGGESTIONS, jsonSuggestions);
         }
 
+        if (this.hasSearchAfter()) {
+            json.put(JSON_FIELD_SEARCH_AFTER, searchAfter);
+        }
+        
         return json;
     }
 

--- a/src/test/java/com/hubrick/vertx/elasticsearch/SearchOptionsTest.java
+++ b/src/test/java/com/hubrick/vertx/elasticsearch/SearchOptionsTest.java
@@ -22,6 +22,7 @@ import com.hubrick.vertx.elasticsearch.model.ScriptSortOption;
 import com.hubrick.vertx.elasticsearch.model.SearchOptions;
 import com.hubrick.vertx.elasticsearch.model.SearchType;
 import com.hubrick.vertx.elasticsearch.model.SortOrder;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.junit.Test;
 
@@ -66,7 +67,9 @@ public class SearchOptionsTest {
                 .addFieldSort("status", SortOrder.ASC)
                 .addFieldSort("insert_date", SortOrder.ASC)
                 .addScripSort("doc['score']", ScriptSortOption.Type.NUMBER, new JsonObject(), SortOrder.ASC)
-                .addScriptField("script_field", "doc['score']", "painless", new JsonObject().put("param1", ImmutableList.of("1", "2", "3")));
+                .addScriptField("script_field", "doc['score']", "painless", new JsonObject().put("param1", ImmutableList.of("1", "2", "3")))
+                .setSearchAfter(new JsonArray().add(1).add("test"))
+        ;
 
         json1 = options1.toJson();
 


### PR DESCRIPTION
This patch adds the ability to specify a 'search_after' search option as defined in ElasticSearch 5+ API (https://www.elastic.co/guide/en/elasticsearch/reference/5.6/search-request-search-after.html)